### PR TITLE
Fixed a case in which Session::destroy does not function properly

### DIFF
--- a/cl/classes/Session.php
+++ b/cl/classes/Session.php
@@ -62,6 +62,8 @@ class Session
      */
     public static function destroy()
     {
+        unset($_SESSION);
+        self::$instance = null;
         return session_destroy();
     }
 


### PR DESCRIPTION
以下の問題の修正。ひとつ目の挙動は意図した挙動かもしれないけど・・・。

Session::destroy()後にSession::get()を行うと削除した値を取得できてしまう
```
Session::set('k', 'v');
echo Session::get('k'); // v

Session::destroy();
echo Session::get('k'); // v
```

Session::destroy()後にSession::set()を行うと、削除した値が再度Sessionに登録される
```
Session::set('k', 'v');
echo Session::get('k'); // v

Session::destroy();

Session::set('another_key', 'foo');
echo Session::get('another_key'); //foo
echo Session::get('k'); //v
```