### PR TITLE
Fixed Pager::hasNext()

### DIFF
--- a/cl/classes/Pager.php
+++ b/cl/classes/Pager.php
@@ -134,7 +134,7 @@ class Pager
         $perPage = $this->perPage;
         $allCount = $this->allCount;
 
-        $hasNext = (($currentPage + 1) * $perPage) <= $allCount;
+        $hasNext = ($currentPage + 1) <= $this->_pages();
 
         if ($content !== null and $hasNext) {
             $this->render($currentPage + 1, $content);


### PR DESCRIPTION
Pager::hasNext()が次のページが有るにも関わらずfalseを返す問題を修正。
検証コード

```
//データ101件
$contents = range(1, 101);
//1ページに表示する件数
$perPage = 10;

for($i = 1; $i <= ceil(count($contents) / $perPage); ++$i) {
        Pager::init($i, count($contents), $perPage);
        printf('currentPage: %d, contents: [%s], hasNext: %b<br>', $i, implode(array_slice($contents, $perPage * ($i - 1), $perPage), ', '), Pager::hasNext());
    }
```

```
currentPage: 1, contents: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], hasNext: 1
currentPage: 2, contents: [11, 12, 13, 14, 15, 16, 17, 18, 19, 20], hasNext: 1
currentPage: 3, contents: [21, 22, 23, 24, 25, 26, 27, 28, 29, 30], hasNext: 1
currentPage: 4, contents: [31, 32, 33, 34, 35, 36, 37, 38, 39, 40], hasNext: 1
currentPage: 5, contents: [41, 42, 43, 44, 45, 46, 47, 48, 49, 50], hasNext: 1
currentPage: 6, contents: [51, 52, 53, 54, 55, 56, 57, 58, 59, 60], hasNext: 1
currentPage: 7, contents: [61, 62, 63, 64, 65, 66, 67, 68, 69, 70], hasNext: 1
currentPage: 8, contents: [71, 72, 73, 74, 75, 76, 77, 78, 79, 80], hasNext: 1
currentPage: 9, contents: [81, 82, 83, 84, 85, 86, 87, 88, 89, 90], hasNext: 1
currentPage: 10, contents: [91, 92, 93, 94, 95, 96, 97, 98, 99, 100], hasNext: 0 // WTF
currentPage: 11, contents: [101], hasNext: 0
```
